### PR TITLE
Fix GH workflow permissions

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,11 +4,17 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     types: [ opened, reopened, synchronize ]
 
 jobs:
   update_release_draft:
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "main"

--- a/.github/workflows/size-label.yml
+++ b/.github/workflows/size-label.yml
@@ -1,11 +1,15 @@
 name: Size Label
 
 on:
-  pull_request_target:
+  pull_request:
     types: [ assigned, opened, synchronize, reopened ]
 
 jobs:
   size-label:
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: size-label


### PR DESCRIPTION
# Proposed Changes

Switch from `pull_request_target` to `pull_request` in release drafter and size workflow by setting the correct workflow permissions.