### PR TITLE
Bump golang to 1.22.3

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,4 +17,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.55.2
+          version: v1.58.0

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
     types: [ opened, reopened, synchronize ]
 
 jobs:

--- a/.github/workflows/size-label.yml
+++ b/.github/workflows/size-label.yml
@@ -1,7 +1,7 @@
 name: Size Label
 
 on:
-  pull_request:
+  pull_request_target:
     types: [ assigned, opened, synchronize, reopened ]
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -72,8 +72,8 @@ GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
 ADDLICENSE_VERSION ?= v1.1.1
-GOIMPORTS_VERSION ?= v0.13.0
-GOLANGCI_LINT_VERSION ?= v1.55.2
+GOIMPORTS_VERSION ?= v0.21.0
+GOLANGCI_LINT_VERSION ?= v1.58.0
 
 .PHONY: addlicense
 addlicense: $(ADDLICENSE) ## Download addlicense locally if necessary.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/afritzler/streetlogr
 
-go 1.21.2
+go 1.22.3
 
 require (
 	github.com/go-logr/logr v1.4.1


### PR DESCRIPTION
# Proposed Changes

- Bump golang to 1.22.3
- Bump golangcilint to 1.58.0
- Change trigger for size and release drafter workflow
- Bump goimports to 0.21.0